### PR TITLE
Initial alarm support, event logging support, with examples.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv3028c7-rtc"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Todd Stellanova <tstellanova@users.noreply.github.com>"]
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ categories = ["embedded", "hardware-support", "no-std"]
 [dependencies]
 embedded-hal = "0.2.7"
 rtcc = "0.3.0"
+chrono = {version = "0.4.31", default-features = false }
 
 [dev-dependencies]
 embedded-hal-mock = "0.9.0"
-chrono = "0.4.31"
 shared-bus = "0.3.1"
 ds323x="0.5.1"
+chrono = {version = "0.4.31", default-features = false, features = ["alloc","clock"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 linux-embedded-hal = "0.3.0"

--- a/examples/alarm_int.rs
+++ b/examples/alarm_int.rs
@@ -127,7 +127,7 @@ fn main() {
 
     // prep for alarm output on INT pin
     run_iteration(&mut rtc, &alarm_dt, Some(alarm_dt.weekday()),
-                  false, false, false);
+                  false, false, true);
     rtc.toggle_alarm_int_enable(true).unwrap();
     let cur_dt = rtc.datetime().unwrap();
     println!("wait for alarm to trigger..\r\n{} {}",cur_dt, alarm_dt);
@@ -149,7 +149,7 @@ fn main() {
         }
         if alarm_af { break; }
 
-        if cur_dt.minute() > alarm_dt.minute() {
+        if cur_dt.minute() >= alarm_dt.minute() {
             break;
         }
     }

--- a/examples/alarm_int.rs
+++ b/examples/alarm_int.rs
@@ -1,0 +1,131 @@
+extern crate rv3028c7_rtc;
+
+use std::ops::{Add};
+use linux_embedded_hal::I2cdev;
+use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike, Utc, Weekday};
+use rv3028c7_rtc::{RV3028, INVALID_WEEKDAY};
+use std::time::Duration;
+use std::thread::sleep;
+use linux_embedded_hal::{CdevPin, gpio_cdev::{Chip, LineRequestFlags}};
+use embedded_hal::digital::v2::{InputPin};
+use rtcc::DateTimeAccess;
+
+use embedded_hal::blocking::i2c::{Write, Read, WriteRead};
+
+/// Example testing real RTC communications,
+/// assuming linux environment (such as Raspberry Pi 3+)
+/// with RV3028 attached to i2c1.
+/// The following was tested by enabling i2c-1 on a Raspberry Pi 3+
+/// using `sudo raspi-config`
+/// and connecting:
+/// - SDA, SCL, GND, and 3.3V pins from rpi to the RTC
+/// - GPIO 27 (physical pin 13) from rpi to the INT pin of the RTC
+///
+
+fn get_sys_timestamp() -> u32 {
+    let now = Utc::now();
+    let now_timestamp = now.timestamp();
+    now_timestamp.try_into().unwrap()
+}
+
+
+fn run_iteration<I2C,E>(rtc: &mut RV3028<I2C>, alarm_dt: &NaiveDateTime,
+                 weekday: u8,
+                 match_day: bool, match_hour: bool, match_minute: bool)
+    where
+      I2C: Write<Error = E> + Read<Error = E> + WriteRead<Error = E>,
+      E: std::fmt::Debug
+{
+    rtc.set_alarm( &alarm_dt,
+                   if weekday < 7 { weekday } else {INVALID_WEEKDAY},
+                   match_day, match_hour, match_minute).unwrap();
+
+    let (dt, out_weekday, out_match_day, out_match_hour, out_match_minute) =
+      rtc.get_alarm_datetime_wday_matches().unwrap();
+    if weekday < 7 {
+        println!("weekday alarm dt: {} wd: {} match_day {} match_hour {} match_minute {}",
+                 dt, out_weekday, out_match_day, out_match_hour, out_match_minute
+        );
+    }
+    else {
+        println!("date alarm dt: {} wd: {} match_day {} match_hour {} match_minute {}",
+                 dt, out_weekday, out_match_day, out_match_hour, out_match_minute
+        );
+    }
+
+    assert!(!rtc.check_and_clear_alarm().unwrap());// alarm should not trigger
+
+    assert_eq!(match_day, out_match_day);
+    assert_eq!(match_hour, out_match_hour);
+    assert_eq!(match_minute, out_match_minute);
+
+    if weekday < 7 {
+        // weekday-based alarm
+        assert_eq!(out_weekday, weekday);
+    }
+    else {
+        // date-based alarm
+        assert_eq!(out_weekday, INVALID_WEEKDAY);
+        assert_eq!(dt.date().day(), alarm_dt.date().day());
+    }
+
+    assert_eq!(dt.time().hour(), alarm_dt.time().hour());
+    assert_eq!(dt.time().minute(), alarm_dt.time().minute());
+
+}
+
+fn main() {
+    // This is a specific configuration for Raspberry Pi -- YMMV
+    let mut gpiochip = Chip::new("/dev/gpiochip0").unwrap();
+
+    // Grab a GPIO input pin on the host for receiving INT signals from RTC
+    let int_line = gpiochip.get_line(27).unwrap();
+    let handle = int_line.request(LineRequestFlags::INPUT, 1, "gpio_int").unwrap();
+    let int_pin = CdevPin::new(handle).expect("new int_pin");
+
+    // Initialize the I2C device
+    let i2c = I2cdev::new("/dev/i2c-1").expect("Failed to open I2C device");
+    // Create a new instance of the RV3028 driver
+    let mut rtc = RV3028::new(i2c);
+
+    let sys_unix_timestamp = get_sys_timestamp();
+    rtc.set_unix_time(sys_unix_timestamp).expect("set_unix_time");
+    let rtc_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
+    println!("start sys {} rtc {} ", sys_unix_timestamp, rtc_unix_time);
+
+    let init_dt = rtc.datetime().expect("datetime");
+    let alarm_dt = init_dt.add(Duration::from_secs(120));
+    println!("init_dt:  {}", init_dt);
+    println!("alarm_dt: {}", alarm_dt);
+
+    // date alarm variations
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, true, true, true);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, true, true, false);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, true, false, false);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, false, false, false);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, false, false, true);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, false, true, true);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, false, true, false);
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, true, false, true);
+
+    // weekday alarm variations
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Mon as u8, true, true, true);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Tue as u8, true, true, false);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Wed as u8, true, false, false);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Thu as u8, false, false, false);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Fri as u8, false, false, true);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Sat as u8, false, true, true);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Sun as u8, false, true, false);
+    run_iteration(&mut rtc, &alarm_dt, Weekday::Mon as u8, true, false, true);
+
+    // prep for alarm output on INT pin
+    run_iteration(&mut rtc, &alarm_dt, INVALID_WEEKDAY, false, false, true);
+
+    // rtc.toggle_alarm_int_enable(true).unwrap();
+    // println!("wait for alarm to trigger...");
+    // sleep(Duration::from_secs(65));
+    // assert!(rtc.check_and_clear_alarm().unwrap());// alarm should trigger
+
+    sleep(Duration::from_secs(1));
+    println!("int pin low? {} ", int_pin.is_low().unwrap());
+}

--- a/examples/comp.rs
+++ b/examples/comp.rs
@@ -3,12 +3,11 @@ extern crate rv3028c7_rtc;
 use core::convert::TryInto;
 use linux_embedded_hal::I2cdev;
 use chrono::{Utc};
-use rv3028c7_rtc::RV3028;
+use rv3028c7_rtc::{RV3028, DateTimeAccess};
 use std::time::{Duration };
 use std::thread::sleep;
 use ds323x::Ds323x;
-
-
+use embedded_hal::blocking::i2c::Write;
 
 /**
 Example comparing set/get of date and time for two different models of RTC,

--- a/examples/event_log.rs
+++ b/examples/event_log.rs
@@ -1,8 +1,8 @@
 extern crate rv3028c7_rtc;
 
 use linux_embedded_hal::I2cdev;
-use chrono::{ Utc};
-use rv3028c7_rtc::{RV3028, EventTimeStampLogger};
+use chrono::{NaiveDateTime, NaiveTime, Utc};
+use rv3028c7_rtc::{RV3028, EventTimeStampLogger, TS_EVENT_SOURCE_EVI};
 use std::time::Duration;
 use std::thread::sleep;
 // use sysfs_gpio::{Pin, Direction};
@@ -20,10 +20,10 @@ use rtcc::DateTimeAccess;
 /// and connecting the SDA, SCL, GND, and 3.3V pins from RPi to the RTC
 /// and connecting a gpio pin (Pin 17 in this case) from rpi to the EVI pin of the RTC
 
-fn get_sys_timestamp() -> u32 {
+fn get_sys_timestamp() -> (NaiveDateTime, u32) {
     let now = Utc::now();
     let now_timestamp = now.timestamp();
-    now_timestamp.try_into().unwrap()
+    (now.naive_utc(), now_timestamp.try_into().unwrap() )
 }
 
 
@@ -33,8 +33,8 @@ fn main() {
     let mut gpiochip = Chip::new("/dev/gpiochip0").unwrap();
     let line = gpiochip.get_line(17).unwrap();
     let handle = line.request(LineRequestFlags::OUTPUT, 1, "gpio_evi").unwrap();
-    let mut evi_pin = CdevPin::new(handle).expect("new CdevPin");
-    evi_pin.set_low().expect("set low");
+    let mut evi_pin = CdevPin::new(handle).unwrap();
+    evi_pin.set_low().unwrap();
 
     // Initialize the I2C device
     let i2c = I2cdev::new("/dev/i2c-1")
@@ -44,37 +44,44 @@ fn main() {
     // Create a new instance of the RV3028 driver
     let mut rtc = RV3028::new(i2c_bus.acquire_i2c());
 
-    let sys_unix_timestamp = get_sys_timestamp();
-    rtc.set_unix_time(sys_unix_timestamp).expect("set_unix_time");
-    let rtc_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
-    println!("start sys {} rtc {} ", sys_unix_timestamp, rtc_unix_time);
+    let (sys_datetime, sys_unix_timestamp) = get_sys_timestamp();
+    // use the set_datetime method to ensure all the timekeeping registers on
+    // the rtc are aligned to the same values
+    rtc.set_datetime(&sys_datetime).unwrap();
+    let rtc_unix_time = rtc.get_unix_time().unwrap();
+    // verify that the individual year, month, day registers are set correctly
+    let (year, month, day) = rtc.get_ymd().unwrap();
+    println!("start sys {} rtc {} ymd {} {} {} ", sys_unix_timestamp, rtc_unix_time, year,month,day);
 
-    let init_dt = rtc.datetime().expect("datetime");
+
+    let init_dt = rtc.datetime().unwrap();
     println!("init_dt: {}", init_dt);
 
     // clear any existing event logging
     rtc.toggle_event_log(false).unwrap();
+    rtc.set_event_source(TS_EVENT_SOURCE_EVI).unwrap();
     rtc.toggle_event_high_low(true).unwrap();
     // allow saving of the latest event time stamp
-    rtc.toggle_time_stamp_overwrite(true).expect("toggle_time_stamp_overwrite");
+    rtc.toggle_time_stamp_overwrite(true).unwrap();
     sleep(Duration::from_millis(100));
     rtc.toggle_event_log(true).unwrap();
 
-    let (event_count, dt) =
-      rtc.get_event_count_and_datetime().expect("get_event_count_and_datetime");
+    let (event_count, odt) =
+      rtc.get_event_count_and_datetime().unwrap();
     if 0 != event_count {
-        println!("init count: {} dt: {}", event_count, dt);
+        println!("init count: {} dt: {}", event_count, odt.unwrap());
     }
 
     let mut toggle_count: u32 = 0;
     for _i in 0..90 {
-        evi_pin.set_high().expect("EVI set high");
+        evi_pin.set_high().unwrap();
         sleep(Duration::from_micros(100));
-        evi_pin.set_low().expect("EVI set low");
+        evi_pin.set_low().unwrap();
         toggle_count += 1;
-        let (event_count, dt) =
-          rtc.get_event_count_and_datetime().expect("get_event_count_and_datetime");
+        let (event_count, odt) =
+          rtc.get_event_count_and_datetime().unwrap();
         if 0 != event_count {
+            let dt = odt.unwrap();
             let now = Utc::now();
             println!("toggles: {} count: {} dt: {} sys: {}", toggle_count, event_count, dt, now);
         }

--- a/examples/event_log.rs
+++ b/examples/event_log.rs
@@ -1,0 +1,72 @@
+extern crate rv3028c7_rtc;
+
+use linux_embedded_hal::I2cdev;
+use chrono::{ Utc};
+use rv3028c7_rtc::{RV3028, EventTimeStampLogger};
+use std::time::Duration;
+use std::thread::sleep;
+
+
+
+
+/// Example testing real RTC communications,
+/// assuming linux environment (such as Raspberry Pi 3+)
+/// with RV3028 attached to i2c1.
+/// The following was tested by enabling i2c-1 on a Raspberry Pi 3+
+/// using `sudo raspi-config`
+/// and connecting the SDA, SCL, GND, and 3.3V pins from RPi to the RTC
+/// and connecting a gpio pin from rpi to the EVI pin of the RTC
+
+fn get_sys_timestamp() -> u32 {
+    let now = Utc::now();
+    let now_timestamp = now.timestamp();
+    now_timestamp.try_into().unwrap()
+}
+
+fn main() {
+
+    // Initialize the I2C device
+    let i2c = I2cdev::new("/dev/i2c-1")
+        .expect("Failed to open I2C device");
+
+    // Create a new instance of the RV3028 driver
+    let mut rtc = RV3028::new(i2c);
+    rtc.toggle_event_log(true).unwrap();
+
+    loop {
+
+        let rtc_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
+        let sys_unix_timestamp = get_sys_timestamp();
+        println!("{}, {}", sys_unix_timestamp, rtc_unix_time);
+        sleep(Duration::from_secs(60));
+    }
+
+    // // Pull the current system time and synchronize RTC time to that
+    // let (_now_timestamp, now_year, now_month, now_date, now_hour, now_minute, now_second) =
+    //     get_sys_date_time();
+    // let input_unix_time: u32 = get_sys_timestamp();
+    // rtc.set_unix_time(input_unix_time).expect("couldn't set unix time");
+    // let output_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
+    // println!("unix timestamp in: {} out: {}", input_unix_time, output_unix_time);
+    //
+    // println!("sys date: {}-{:02}-{:02}", (2000u32 + now_year as u32), now_month, now_date);
+    // let (year, month, day) = rtc.get_year_month_day()
+    //     .expect("Failed to get date");
+    // println!("rtc date: {}-{:02}-{:02}", (2000u32 + year as u32), month, day);
+    //
+    // let (hours, minutes, seconds) = rtc.get_time()
+    //     .expect("Failed to get time");
+    // println!("rtc time: {:02}:{:02}:{:02}", hours, minutes, seconds);
+    // println!("sys time: {:02}:{:02}:{:02}", now_hour, now_minute, now_second);
+    //
+
+    // // check the drift over and over again
+    // loop {
+    //     let rtc_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
+    //     let sys_unix_timestamp = get_sys_timestamp();
+    //     println!("{}, {}", sys_unix_timestamp, rtc_unix_time);
+    //     sleep(Duration::from_secs(60));
+    // }
+
+
+}

--- a/examples/rpil.rs
+++ b/examples/rpil.rs
@@ -1,78 +1,62 @@
 extern crate rv3028c7_rtc;
 
 use linux_embedded_hal::I2cdev;
-use chrono::{Datelike, Timelike, Utc};
+use chrono::{Datelike, NaiveDateTime, Timelike, Utc};
 use rv3028c7_rtc::RV3028;
 use std::time::Duration;
 use std::thread::sleep;
+use rtcc::DateTimeAccess;
 
 
+/// Example testing real RTC communications,
+/// assuming linux environment (such as Raspberry Pi 3+)
+/// with RV3028 attached to i2c1.
+/// The following was tested by enabling i2c-1 on a Raspberry Pi 3+
+/// using `sudo raspi-config`
+/// and connecting the SDA, SCL, GND, and 3.3V pins from RPi to the RTC
 
-/**
-Example testing real RTC communications,
-assuming linux environment (such as Raspberry Pi 3+)
-with RV3028 attached to i2c1.
-The following was tested by enabling i2c-1 on a Raspberry Pi 3+
-using `sudo raspi-config`
-and connecting the SDA, SCL, GND, and 3.3V pins from RPi to the RTC
-*/
 
-fn get_sys_date_time() -> (i64, u8, u8, u8, u8, u8, u8)
-{
+fn get_sys_timestamp() -> (NaiveDateTime, u32) {
     let now = Utc::now();
     let now_timestamp = now.timestamp();
-    let now_hour:u8 = now.hour().try_into().unwrap();
-    let now_minute:u8 = now.minute().try_into().unwrap();
-    let now_second: u8 = now.second().try_into().unwrap();
-    let now_date:u8 = now.day().try_into().unwrap();
-    let now_month:u8 = now.month().try_into().unwrap();
-    // the RTC only handles years in the 0..99 range (corresponding with 2000 to 2099)
-    let now_year: u32 = now.year().try_into().unwrap();
-    //println!("src time: {:02}:{:02}:{:02}", now_hour, now_minute, now_second);
-    //println!("src date: {}-{:02}-{:02}", now_year, now_month, now_date);
-    let now_year:u8 = (now_year - 2000u32).try_into().unwrap();
-    (now_timestamp, now_year, now_month, now_date, now_hour, now_minute, now_second)
-}
-
-fn get_sys_timestamp() -> u32 {
-    let now = Utc::now();
-    let now_timestamp = now.timestamp();
-    now_timestamp.try_into().unwrap()
+    (now.naive_utc(), now_timestamp.try_into().unwrap() )
 }
 
 fn main() {
 
     // Initialize the I2C device
-    let i2c = I2cdev::new("/dev/i2c-1")
-        .expect("Failed to open I2C device");
+    let i2c = I2cdev::new("/dev/i2c-1").expect("Failed to open I2C device");
 
     // Create a new instance of the RV3028 driver
     let mut rtc = RV3028::new(i2c);
 
     // Pull the current system time and synchronize RTC time to that
-    let (_now_timestamp, now_year, now_month, now_date, now_hour, now_minute, now_second) =
-        get_sys_date_time();
-    let input_unix_time: u32 = get_sys_timestamp();
-    rtc.set_unix_time(input_unix_time).expect("couldn't set unix time");
-    let output_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
-    println!("unix timestamp in: {} out: {}", input_unix_time, output_unix_time);
+    let (sys_datetime, sys_unix_timestamp) = get_sys_timestamp();
+    // use the set_datetime method to ensure all the timekeeping registers on
+    // the rtc are aligned to the same values
+    rtc.set_datetime(&sys_datetime).unwrap();
 
-    println!("sys date: {}-{:02}-{:02}", (2000u32 + now_year as u32), now_month, now_date);
-    let (year, month, day) = rtc.get_year_month_day()
-        .expect("Failed to get date");
-    println!("rtc date: {}-{:02}-{:02}", (2000u32 + year as u32), month, day);
+    // verify that the unix time and the
+    // individual year, month, day registers are set correctly
+    let rtc_unix_time = rtc.get_unix_time().unwrap();
+    println!("unix sys {} rtc {}  ", sys_unix_timestamp, rtc_unix_time);
 
-    let (hours, minutes, seconds) = rtc.get_time()
-        .expect("Failed to get time");
-    println!("rtc time: {:02}:{:02}:{:02}", hours, minutes, seconds);
-    println!("sys time: {:02}:{:02}:{:02}", now_hour, now_minute, now_second);
+    println!("sys date: {}-{:02}-{:02}",
+             sys_datetime.date().year(), sys_datetime.date().month(), sys_datetime.date().day());
+    let (year, month, day) = rtc.get_ymd().unwrap();
+    println!("rtc date: {}-{:02}-{:02}", year, month, day);
+
+    let (hours, minutes, seconds) = rtc.get_hms().unwrap();
+    println!("rtc time: {:02}:{:02}:{:02}",
+             hours, minutes, seconds);
+    println!("sys time: {:02}:{:02}:{:02}",
+             sys_datetime.time().hour(), sys_datetime.time().minute(), sys_datetime.time().second());
 
 
     // check the drift over and over again
     loop {
-        let rtc_unix_time = rtc.get_unix_time().expect("couldn't get unix time");
-        let sys_unix_timestamp = get_sys_timestamp();
-        println!("{}, {}", sys_unix_timestamp, rtc_unix_time);
+        let dt = rtc.datetime().unwrap();
+        println!("sys {}\r\nrtc {}", Utc::now().naive_utc(), dt);
         sleep(Duration::from_secs(60));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 
 
+
 pub use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike, Weekday};
 pub use rtcc::{  DateTimeAccess };
 
@@ -406,7 +407,7 @@ impl<I2C, E> RV3028<I2C>
   /// return bool indicating whether the alarm triggered
   pub fn check_and_clear_alarm(&mut self) -> Result<bool, E> {
     let reg_val = self.read_register(REG_STATUS)?;
-    let alarm_flag_set = 0 != (reg_val & ALARM_FLAG_BIT);
+    let alarm_flag_set =  0 != (reg_val & ALARM_FLAG_BIT); // Check if the AF flag is set
     if alarm_flag_set {
       self.clear_reg_bits(REG_STATUS, ALARM_FLAG_BIT)?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,14 @@
 
 
 pub use rtcc::{
-  DateTimeAccess, NaiveDate, NaiveDateTime
+  DateTimeAccess, NaiveDate, NaiveDateTime, Datelike, Timelike,
 };
 
 
 
 use embedded_hal::blocking::i2c::{Write, Read, WriteRead};
 
-// i2c address of the device (7-bit)
+// Fixed i2c bus address of the device (7-bit)
 const RV3028_ADDRESS: u8 = 0xA4 >> 1;
 
 // Register addresses
@@ -18,16 +18,15 @@ const REG_MINUTES: u8 = 0x01;
 const REG_HOURS: u8 = 0x02;
 
 
-/// Holds the current day of the week.
-/// Each value represents one weekday that is assigned by the user.
-/// Values will range from 0 to 6.
-/// The weekday counter is simply a 3-bit counter which counts up to 6 and then resets to 0.
+// Holds the current day of the week.
+// Each value represents one weekday that is assigned by the user.
+// Values will range from 0 to 6.
+// The weekday counter is simply a 3-bit counter which counts up to 6 and then resets to 0.
 const REG_WEEKDAY: u8 = 0x03;
 
-
-/// Holds the current day of the month, in two binary coded decimal (BCD) digits.
-/// Values will range from 01 to 31.
-/// Leap years are correctly handled from 2000 to 2099.
+// Holds the current day of the month, in two binary coded decimal (BCD) digits.
+// Values will range from 01 to 31.
+// Leap years are correctly handled from 2000 to 2099.
 const REG_DATE: u8 = 0x04;
 
 // Holds the current month, in two binary coded decimal (BCD) digits.
@@ -53,7 +52,7 @@ const REG_MINUTES_ALARM: u8 = 0x07;
 const REG_HOURS_ALARM: u8 = 0x08;
 
 // Holds the Weekday/Date Alarm (WADA) Enable bit AE_WD.
-// - If the WADA bit is 0 (Bit 5 in Register 0Fh),
+// - If the WADA bit is 0 (Bit 5 in Register REG_CONTROL1),
 // it holds the alarm value for the weekday (weekdays assigned by the user),
 // in two binary coded decimal (BCD) digits.
 // Values will range from 0 to 6.
@@ -64,15 +63,15 @@ const REG_WEEKDAY_DATE_ALARM: u8 = 0x09;
 // 0Ah – Timer Value 0
 // 0Bh – Timer Value 1
 
-
 // This register is used to detect the occurrence of various interrupt events
 // and reliability problems in internal data.
 const REG_STATUS: u8 = 0x0E;
 
-// This register is used to specify the target for the Alarm Interrupt function
-// and the Periodic Time Update Interrupt function
-// and to select or set operations for the Periodic Countdown Timer.
-// const REG_CONTROL1:u8  = 0x0F;
+// This register is used to configure
+// - the Alarm Interrupt function
+// - the Periodic Time Update Interrupt function
+// - and to select or set operations for the Periodic Countdown Timer.
+const REG_CONTROL1:u8  = 0x0F;
 
 // This register is used to control:
 // - interrupt event output for the INT̅ pin
@@ -81,17 +80,17 @@ const REG_STATUS: u8 = 0x0E;
 // - hour mode and time stamp enable
 const REG_CONTROL2:u8 = 0x10;
 
-// Event Control R/WP ○ EHL ET ○ TSR TSOW TSS
+// Event Control register: EHL, ET,TSR, TSOW, TSS
 const REG_EVENT_CONTROL: u8 = 0x13;
 
 // Time Stamp function registers (Event Logging)
 const REG_COUNT_EVENTS_TS: u8 = 0x14; // Count TS
-const REG_SECONDS_TS: u8 = 0x15; // Seconds TS
-const REG_MINUTES_TS: u8 = 0x16; // Minutes TS
-const REG_HOURS_TS: u8 = 0x17; // Hours TS
-const REG_DATE_TS: u8 = 0x18; // Date TS
-const REG_MONTH_TS: u8 = 0x19; // Month TS
-const REG_YEAR_TS: u8 = 0x1A; // Month TS
+// const REG_SECONDS_TS: u8 = 0x15; // Seconds TS
+// const REG_MINUTES_TS: u8 = 0x16; // Minutes TS
+// const REG_HOURS_TS: u8 = 0x17; // Hours TS
+// const REG_DATE_TS: u8 = 0x18; // Date TS
+// const REG_MONTH_TS: u8 = 0x19; // Month TS
+// const REG_YEAR_TS: u8 = 0x1A; // Month TS
 
 
 // First address of "Unix Time Counter"
@@ -100,39 +99,54 @@ const REG_UNIX_TIME_0: u8 = 0x1B;
 // const REG_UNIX_TIME_2: u8 = 0x1D;
 // const REG_UNIX_TIME_3: u8 = 0x1E;
 
-// Control1 register bits:
-// const EERD_BIT: u8 = 1 << 3;
+// REG_CONTROL1 "Control 1" register bits:
+const WADA_BIT: u8 = 1 << 5; // Weekday Alarm / Date Alarm selection bit WADA
 // const USEL_BIT: u8 = 1 << 4;
-// const WADA_BIT: u8 = 1 << 5;
+// const EERD_BIT: u8 = 1 << 3;
 
-// Status register bits:
+
+// REG_STATUS Status register bits:
 // const EEBUSY_BIT: u8 = 1 << 7;
-const EVENT_FLAG_BIT: u8 = 1 << 1; // EVT bit
+const BACKUP_SWITCH_FLAG: u8 = 1 << 4; // BSF bit
+const ALARM_FLAG_BIT : u8 = 1 << 2; // AF / Alarm Flag
+const EVENT_FLAG_BIT: u8 = 1 << 1; // EVF / Event Flag
 
 // EEPROM register addresses and commands
-pub const EEPROM_ADDRESS: u8 = 0x37;
-pub const EEPROM_CMD_READ: u8 = 0x00;
-pub const EEPROM_CMD_WRITE: u8 = 0x01;
+const EEPROM_MIRROR_ADDRESS: u8 = 0x37;// RAM mirror of EEPROM config values
+// const EEPROM_CMD_READ: u8 = 0x00;
+// const EEPROM_CMD_WRITE: u8 = 0x01;
 
 
-// Event Control register bits  R/WP ○ EHL ET ○ TSR TSOW TSS
+// REG_EVENT_CONTROL Event Control register bits:   EHL, ET, TSR, TSOW, TSS
+const EVENT_HIGH_LOW_BIT: u8 = 1 << 6; // EHL bit
 const TIME_STAMP_RESET_BIT: u8 = 1 << 2; // TSR bit
 const TIME_STAMP_OVERWRITE_BIT: u8 = 1 << 1; // TSOW bit
 const TIME_STAMP_SOURCE_BIT: u8 = 1 << 0; // TSS bit
 
-pub const TS_EVENT_SOURCE_EVI: u8 = 0; /// Event log event source is external interrupt EVI
-pub const TS_EVENT_SOURCE_BSF: u8 = 1; /// Event log event source is backup power switchover
+pub const TS_EVENT_SOURCE_EVI: u8 = 0; /// Event log source is external interrupt EVI (default)
+pub const TS_EVENT_SOURCE_BSF: u8 = 1; /// Event log source is backup power switchover
 
+// REG_CONTROL2 "Control 2" register bits: TSE CLKIE UIE TIE AIE EIE 12_24 RESET
+const TIME_STAMP_ENABLE_BIT: u8 = 1 << 7; // TSE / Time Stamp Enable bit
+const ALARM_INT_ENABLE_BIT: u8 = 1 << 3;// AIE / Alarm Interrupt Enable bit
+const EVENT_INT_ENABLE_BIT: u8 = 1 << 2;// EIE / Event Interrupt Enable bit
 
-// Control2 register bits: TSE CLKIE UIE TIE AIE EIE 12_24 RESET
-const TIME_STAMP_ENABLE_BIT: u8 = 1 << 7; // TSE bit
 
 // EEPROM register bits:
 const TRICKLE_CHARGE_ENABLE_BIT: u8 = 1 << 5; // TCE bit
-// const TRICKLE_CHARGE_RESISTANCE_BITS_3K: u8 = 0b00; // TCR bit
-// const TRICKLE_CHARGE_RESISTANCE_BITS_5K: u8 = 0b01;
-// const TRICKLE_CHARGE_RESISTANCE_BITS_9K: u8 = 0b10;
-// const TRICKLE_CHARGE_RESISTANCE_BITS_15K: u8 = 0b11;
+// const TRICKLE_CHARGE_RESISTANCE_BITS: u8 = 1 << 0; // TCR bit
+// pub const TRICKLE_CHARGE_RESISTANCE_VALUE_3K: u8 = 0b00;
+// pub const TRICKLE_CHARGE_RESISTANCE_VALUE_5K: u8 = 0b01;
+// pub const TRICKLE_CHARGE_RESISTANCE_VALUE_9K: u8 = 0b10;
+// pub const TRICKLE_CHARGE_RESISTANCE_VALUE_15K: u8 = 0b11;
+
+/// Days of week are 0..6 as defined by chrono::Weekday
+/// This value represents a known invalid weekday
+pub const INVALID_WEEKDAY:u8 = 28;
+
+// Special alarm register value
+const ALARM_NO_WATCH_FLAG: u8 = 1 <<  7;
+
 
 /// RV-3028-C7
 /// Extreme Low Power Real-Time Clock (RTC) Module with I2C-Bus Interface
@@ -147,6 +161,7 @@ impl<I2C, E> RV3028<I2C>
   where
     I2C: Write<Error = E> + Read<Error = E> + WriteRead<Error = E>,
 {
+
   /// New driver instance, assumes that there is no i2c mux
   /// sitting between the RTC and the host.
   pub fn new(i2c: I2C) -> Self {
@@ -169,17 +184,17 @@ impl<I2C, E> RV3028<I2C>
     }
   }
 
-  /// Converts a binary value to BCD format
+  // Converts a binary value to BCD format
   fn bin_to_bcd(value: u8) -> u8 {
     ((value / 10) << 4) | (value % 10)
   }
 
-  /// Converts a BCD value to binary format
+  // Converts a BCD value to binary format
   fn bcd_to_bin(value: u8) -> u8 {
     ((value & 0xF0) >> 4) * 10 + (value & 0x0F)
   }
 
-  /// If using an i2c mux, tell the mux to select our channel
+  // If using an i2c mux, tell the mux to select our channel
   fn select_mux_channel(&mut self) -> Result<(), E> {
     if self.mux_addr != 0u8 {
       self.i2c.write(self.mux_addr, &[self.mux_chan])
@@ -239,34 +254,31 @@ impl<I2C, E> RV3028<I2C>
   //   res
   // }
 
-
+  // set specific bits in a register:
+  // all bits must be high that you wish to set
   fn set_reg_bits(&mut self, reg: u8, bits: u8) -> Result<(), E> {
     let mut reg_val = self.read_register(reg)?;
     reg_val |= bits; // Set bits that are high
     self.write_register(reg, reg_val)
   }
 
-  // clear specific bits in a register -- all bits must be high
-  // that you desire to be cleared
+  // clear specific bits in a register:
+  // all bits must be high that you wish to be cleared
   fn clear_reg_bits(&mut self, reg: u8, bits: u8) -> Result<(), E> {
     let mut reg_val = self.read_register(reg)?;
     reg_val &= !(bits); // Clear  bits that are high
     self.write_register(reg, reg_val)
   }
 
-  /// Disable trickle charging of the VBACKUP power source
-  pub fn disable_trickle_charge(&mut self) -> Result<(), E> {
-    self.clear_reg_bits(EEPROM_ADDRESS, TRICKLE_CHARGE_ENABLE_BIT)
+  /// Enable or disable trickle charging
+  pub fn toggle_trickle_charge(&mut self, enable: bool) -> Result<(), E>  {
+    self.set_or_clear_reg_bits(EEPROM_MIRROR_ADDRESS, TRICKLE_CHARGE_ENABLE_BIT, enable)
   }
 
-  /// Enable trickle charging of the VBACKUP power source
-  pub fn enable_trickle_charge(&mut self) -> Result<(), E> {
-    self.set_reg_bits(EEPROM_ADDRESS, TRICKLE_CHARGE_ENABLE_BIT)
-  }
 
-  /// Get the current value of the EEPROM register
-  pub fn get_eeprom_reg_value(&mut self) -> Result<u8, E> {
-    let reg_val = self.read_register(EEPROM_ADDRESS)?;
+  /// Get the current value of the EEPROM mirror from RAM
+  pub fn get_eeprom_mirror_value(&mut self) -> Result<u8, E> {
+    let reg_val = self.read_register(EEPROM_MIRROR_ADDRESS)?;
     Ok(reg_val)
   }
 
@@ -344,47 +356,6 @@ impl<I2C, E> RV3028<I2C>
     Ok((year,month,day))
   }
 
-  /// Set the minutes for the alarm
-  pub fn set_alarm_minutes(&mut self, minutes: u8) -> Result<(), E> {
-    let bcd_minutes = Self::bin_to_bcd(minutes);
-    self.write_register( REG_MINUTES_ALARM , bcd_minutes)
-  }
-
-  /// Get the minutes for the alarm
-  pub fn get_alarm_minutes(&mut self) -> Result<u8, E> {
-    let bcd_minutes = self.read_register(REG_MINUTES_ALARM)?;
-    Ok(Self::bcd_to_bin(bcd_minutes))
-  }
-
-  /// Set the hours for the alarm
-  pub fn set_alarm_hours(&mut self, hours: u8) -> Result<(), E> {
-    let bcd_hours = Self::bin_to_bcd(hours);
-    self.write_register(REG_HOURS_ALARM , bcd_hours)
-  }
-
-  /// Get the hours for the alarm
-  pub fn get_alarm_hours(&mut self) -> Result<u8, E> {
-    let bcd_hours = self.read_register(REG_HOURS_ALARM)?;
-    Ok(Self::bcd_to_bin(bcd_hours))
-  }
-
-  /// Set the weekday/date for the alarm
-  /// - `is_weekday` is true for weekday, false for date
-  pub fn set_alarm_weekday_date(&mut self, value: u8, is_weekday: bool) -> Result<(), E> {
-    let bcd_value = Self::bin_to_bcd(value);
-    let alarm_value = if is_weekday { bcd_value } else { bcd_value | 0x40 };
-    self.write_register(REG_WEEKDAY_DATE_ALARM , alarm_value)
-  }
-
-  /// Get the weekday/date for the alarm
-  /// - Returns (value, is_weekday): `is_weekday` is true if the alarm is set for a weekday
-  pub fn get_alarm_weekday_date(&mut self) -> Result<(u8, bool), E> {
-    let alarm_value = self.read_register(REG_WEEKDAY_DATE_ALARM)?;
-    let is_weekday = (alarm_value & 0x40) == 0;
-    let value = if is_weekday { alarm_value & 0x3F } else { alarm_value & 0x1F };
-    Ok((Self::bcd_to_bin(value), is_weekday))
-  }
-
   // read a block of registers all at once
   fn read_multi_registers(&mut self, reg: u8, read_buf: &mut [u8] )  -> Result<(), E> {
     self.select_mux_channel()?;
@@ -407,10 +378,8 @@ impl<I2C, E> RV3028<I2C>
   /// - Note that the RTC's automatic leap year correction is only valid until 2099
   /// See the App Manual section "3.10. UNIX TIME REGISTERS"
   pub fn get_unix_time(&mut self) -> Result<u32, E> {
-    self.select_mux_channel()?;
     let mut read_buf = [0u8; 4];
-    self.read_multi_registers(REG_UNIX_TIME_0,&mut read_buf)?;
-    // self.i2c.write_read(RV3028_ADDRESS, &[REG_UNIX_TIME_0], &mut read_buf)?;
+    self.read_multi_registers(REG_UNIX_TIME_0, &mut read_buf)?;
     let val = u32::from_le_bytes(read_buf);
     Ok(val)
   }
@@ -429,6 +398,121 @@ impl<I2C, E> RV3028<I2C>
     }
   }
 
+  /// Toggle whether EVI events trigger on high/rising or low/falling edges
+  pub fn toggle_event_high_low(&mut self, high: bool) -> Result<(), E> {
+    self.set_or_clear_reg_bits(REG_EVENT_CONTROL, EVENT_HIGH_LOW_BIT, high)
+  }
+
+  /// Toggle whether an alarm outputs an interrupt signal on the INT pin
+  pub fn toggle_alarm_interrupt_out(&mut self, enable: bool) -> Result<(), E> {
+    self.set_or_clear_reg_bits(REG_CONTROL2, ALARM_INT_ENABLE_BIT, enable)
+  }
+
+  /// Check the alarm status, and if it's triggered, clear it
+  /// return bool indicating whether the alarm triggered
+  pub fn check_and_clear_alarm(&mut self) -> Result<bool, E> {
+    let reg_val = self.read_register(REG_STATUS)?;
+    let alarm_flag_set = 0 != (reg_val & ALARM_FLAG_BIT);
+    if alarm_flag_set {
+      self.clear_reg_bits(REG_STATUS, ALARM_FLAG_BIT)?;
+    }
+    Ok(alarm_flag_set)
+  }
+
+  /// All-in-one method to set an alarm:
+  /// See the App Note section "Procedure to use the Alarm Interrupt"
+  /// Note only date/weekday, hour, minute are supported
+  /// - If `weekday` is in the range 0..6 then it'll setup a weekday alarm rather than date alarm
+  /// - `match_day` indicates whether the day (or weekday) should be matched for the alarm
+  /// - `match_hour` indicates whether the hour should be matched for the alarm
+  /// - `match_minute` indicates whether the minutes should be matched for the alarm
+  pub fn set_alarm(&mut self, datetime: &NaiveDateTime,
+                   weekday: u8, match_day: bool, match_hour: bool, match_minute: bool) -> Result<(), E> {
+
+    // Initialize AF to 0; AIE/ALARM_INT_ENABLE_BIT is managed independently
+    self.clear_reg_bits(REG_STATUS, ALARM_FLAG_BIT)?;
+
+    let bcd_hour = Self::bin_to_bcd(datetime.time().hour() as u8);
+    self.write_register(REG_HOURS_ALARM,
+                        if match_hour { bcd_hour  }
+                        else { ALARM_NO_WATCH_FLAG | bcd_hour })?;
+
+    let bcd_minute = Self::bin_to_bcd(datetime.time().minute() as u8);
+    self.write_register(REG_MINUTES_ALARM,
+                        if match_minute { bcd_minute }
+                        else { ALARM_NO_WATCH_FLAG | bcd_minute })?;
+
+    if weekday < 7 { // Clear WADA for weekday alarm
+      let bcd_weekday = Self::bin_to_bcd(weekday);
+      self.clear_reg_bits(REG_CONTROL1, WADA_BIT)?;
+      self.write_register(REG_WEEKDAY_DATE_ALARM,
+                          if match_day { bcd_weekday }
+                          else { ALARM_NO_WATCH_FLAG | bcd_weekday }
+      )?;
+    }
+    else { // Set WADA for date alarm
+      let bcd_day = Self::bin_to_bcd(datetime.date().day() as u8);
+      self.set_reg_bits(REG_CONTROL1, WADA_BIT)?;
+      self.write_register(REG_WEEKDAY_DATE_ALARM,
+                          if match_day { bcd_day }
+                          else { ALARM_NO_WATCH_FLAG | bcd_day })?;
+    }
+    // Clear AF again in case the above setting process immediately triggered the alarm
+    self.clear_reg_bits(REG_STATUS, ALARM_FLAG_BIT)?;
+
+    Ok(())
+  }
+
+  pub fn get_alarm_datetime_wday_matches(&mut self)
+    -> Result<(NaiveDateTime, u8, bool, bool, bool), E> {
+
+    let raw_day = self.read_register(REG_WEEKDAY_DATE_ALARM)?;
+    let match_day = 0 == (raw_day & ALARM_NO_WATCH_FLAG);
+    let day = Self::bcd_to_bin(0x7F & raw_day);
+
+    let raw_hour = self.read_register(REG_HOURS_ALARM)?;
+    let match_hour = 0 == (raw_hour & ALARM_NO_WATCH_FLAG);
+    let hour = Self::bcd_to_bin(0x7F & raw_hour);
+
+    let raw_minutes = self.read_register(REG_MINUTES_ALARM)?;
+    let match_minutes = 0 == (raw_minutes & ALARM_NO_WATCH_FLAG);
+    let minutes = Self::bcd_to_bin(0x7F & raw_minutes);
+
+    let mut weekday: u8 = INVALID_WEEKDAY;
+
+    let wada_state = self.read_register(REG_CONTROL1)? & WADA_BIT;
+
+    let dt =
+      if 0 == wada_state {
+        // weekday alarm
+        weekday = day;
+        NaiveDateTime::UNIX_EPOCH.with_hour(hour as u32).unwrap()
+          .with_minute(minutes as u32).unwrap()
+      }
+      else {
+        // date alarm
+        NaiveDateTime::UNIX_EPOCH.with_day(day as u32).unwrap()
+          .with_hour(hour as u32).unwrap()
+          .with_minute(minutes as u32).unwrap()
+      };
+
+    Ok((dt, weekday, match_day, match_hour, match_minutes))
+  }
+
+  /// Enable INT pin output when alarm occurs
+  pub fn toggle_alarm_int_enable(&mut self, enable: bool) -> Result<(), E> {
+    self.set_or_clear_reg_bits(REG_CONTROL2, ALARM_INT_ENABLE_BIT, enable)
+  }
+
+  // If `set` is true, set the high bits given in `bits`, otherwise clear those bits
+  fn set_or_clear_reg_bits(&mut self, reg: u8, bits: u8, set: bool) -> Result<(), E> {
+    if set {
+      self.set_reg_bits(reg, bits)
+    }
+    else {
+      self.clear_reg_bits(reg, bits)
+    }
+  }
 
 }
 
@@ -445,8 +529,8 @@ pub trait EventTimeStampLogger {
   fn get_event_count_and_datetime(&mut self) -> Result<(u32, NaiveDateTime), Self::Error>;
 
   /// Enable or disable event time stamp overwriting
+  /// If this is disabled (default), the first event time stamp is saved.
   /// If this is enabled, the most recent event time stamp is saved.
-  /// If this is disabled, the first event time stamp is saved.
   fn toggle_time_stamp_overwrite(&mut self, enable: bool) -> Result<(), Self::Error>;
 
   /// Select a source for events to be logged, device-specific
@@ -487,38 +571,54 @@ impl<I2C, E> EventTimeStampLogger for  RV3028<I2C>
 
   fn toggle_event_log(&mut self, enable: bool) -> Result<(), Self::Error> {
     if enable {
-      // prep to start listening for events
-      self.set_reg_bits(REG_CONTROL2, TIME_STAMP_ENABLE_BIT)?;
-      // First reset all the event counters and reset saved event time stamp to zero
+      // App notes recommend first disabling the event log with TSE and setting TSR
+      // Initialize bits TSE and EIE to 0.
+      // 2. Select TSOW (0 or 1), clear EVF and BSF.
+      // 3. Write 1 to TSR bit, to reset all Time Stamp registers to 00h. Bit TSR always returns 0 when read.
+      // 4. Select the External Event Interrupt function (TSS = 0) or the Automatic Backup Switchover Interrupt
+      // function (TSS = 1) as time stamp source and initialize the appropriate function (see EXTERNAL EVENT
+      //                                                                                  INTERRUPT FUNCTION or AUTOMATIC BACKUP SWITCHOVER INTERRUPT FUNCTION).
+      //   5. Set the TSE bit to 1 to enable the Time Stamp function.
+
+      // Initialize bits TSE and EIE to 0.
+      self.clear_reg_bits(REG_CONTROL2, TIME_STAMP_ENABLE_BIT)?;
+      self.clear_reg_bits(REG_CONTROL2, EVENT_INT_ENABLE_BIT)?;
+      // Assume that TSOW has already been selected
+      // Clear the single event detect flag EVF and BSF
+      self.clear_reg_bits(REG_STATUS, EVENT_FLAG_BIT)?;
+      self.clear_reg_bits(REG_STATUS, BACKUP_SWITCH_FLAG)?;
+      // Reset all Time Stamp registers to zero
       self.set_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_RESET_BIT)?;
-      // clear the single event detect flag
-      self.clear_reg_bits(REG_STATUS, EVENT_FLAG_BIT)
+
+      // start listening for events
+      self.set_reg_bits(REG_CONTROL2, TIME_STAMP_ENABLE_BIT)
     }
     else {
+      // stop listening for events
       self.clear_reg_bits(REG_CONTROL2, TIME_STAMP_ENABLE_BIT)
     }
   }
 
   fn get_event_count_and_datetime(&mut self) -> Result<(u32, NaiveDateTime), Self::Error> {
-    // Read the raw Time Stamp Function registers
+    // Read the seven raw Time Stamp Function registers in one go
     let mut read_buf:[u8;7] = [0u8;7];
     self.read_multi_registers(REG_COUNT_EVENTS_TS, &mut read_buf)?;
 
-    let second = Self::bcd_to_bin( read_buf[(REG_SECONDS_TS  - REG_COUNT_EVENTS_TS) as usize]);
-    let minute = Self::bcd_to_bin(read_buf[(REG_MINUTES_TS - REG_COUNT_EVENTS_TS) as usize]);
-    let hour = Self::bcd_to_bin(read_buf[(REG_HOURS_TS - REG_COUNT_EVENTS_TS) as usize]);
-
-    let count =  read_buf[(REG_COUNT_EVENTS_TS - REG_COUNT_EVENTS_TS) as usize];
-    let year: i32 = Self::bcd_to_bin(read_buf[ (REG_YEAR_TS - REG_COUNT_EVENTS_TS) as usize] ).into();
-    let month = Self::bcd_to_bin(read_buf[(REG_MONTH_TS - REG_COUNT_EVENTS_TS) as usize]);
-    let day = Self::bcd_to_bin(read_buf[(REG_DATE_TS - REG_COUNT_EVENTS_TS) as usize]);
+    // Convert BCD values to binary
+    let count = read_buf[0]; // Count is already in binary
 
     let dt = {
       if count > 0 {
-        let date = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
-          .expect("No luck with YMD");
-        date.and_hms_opt(hour as u32, minute as u32, second as u32)
-          .expect("No luck with HMS")
+        let seconds = Self::bcd_to_bin(read_buf[1]);
+        let minutes = Self::bcd_to_bin(read_buf[2]);
+        let hours = Self::bcd_to_bin(read_buf[3]);
+        let date = Self::bcd_to_bin(read_buf[4]);
+        let month = Self::bcd_to_bin(read_buf[5]);
+        let year = Self::bcd_to_bin(read_buf[6]);
+        NaiveDate::from_ymd_opt(year as i32, month as u32, date as u32)
+        .expect("YMD")
+          .and_hms_opt(hours as u32, minutes as u32, seconds as u32)
+          .expect("HMS")
       }
       else {
         NaiveDateTime::from_timestamp_opt(0,0).unwrap()
@@ -530,21 +630,12 @@ impl<I2C, E> EventTimeStampLogger for  RV3028<I2C>
   }
 
   fn toggle_time_stamp_overwrite(&mut self, enable: bool) -> Result<(), Self::Error> {
-    if enable {
-      self.set_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_OVERWRITE_BIT)
-    }
-    else {
-      self.clear_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_OVERWRITE_BIT)
-    }
+    self.set_or_clear_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_OVERWRITE_BIT, enable)
   }
 
   fn set_event_source(&mut self, source: u8) -> Result<(), Self::Error> {
-    if TS_EVENT_SOURCE_EVI == source {
-      self.clear_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_SOURCE_BIT)
-    }
-    else {
-      self.set_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_SOURCE_BIT)
-    }
+    self.set_or_clear_reg_bits(REG_EVENT_CONTROL, TIME_STAMP_SOURCE_BIT,
+                               TS_EVENT_SOURCE_EVI != source)
   }
 
 }
@@ -582,34 +673,34 @@ mod tests {
     assert_eq!(seconds, 58);
   }
 
-  #[test]
-  fn test_set_alarm_minutes() {
-    let expectations = [I2cTrans::write(RV3028_ADDRESS, vec![ REG_MINUTES_ALARM, RV3028::<I2cMock>::bin_to_bcd(15)])];
-    let mock = I2cMock::new(&expectations);
-    let mut rv3028 = RV3028::new(mock);
-    rv3028.set_alarm_minutes(15).unwrap();
-  }
+  // #[test]
+  // fn test_set_alarm_minutes() {
+  //   let expectations = [I2cTrans::write(RV3028_ADDRESS, vec![ REG_MINUTES_ALARM, RV3028::<I2cMock>::bin_to_bcd(15)])];
+  //   let mock = I2cMock::new(&expectations);
+  //   let mut rv3028 = RV3028::new(mock);
+  //   rv3028.set_alarm_minutes(15).unwrap();
+  // }
 
-  #[test]
-  fn test_get_alarm_minutes() {
-    let expectations = [
-      I2cTrans::write_read(RV3028_ADDRESS, vec![REG_MINUTES_ALARM], vec![RV3028::<I2cMock>::bin_to_bcd(15)]),
-    ];
-    let mock = I2cMock::new(&expectations);
-    let mut rv3028 = RV3028::new(mock);
-    assert_eq!(rv3028.get_alarm_minutes().unwrap(), 15);
-  }
-
-  //TODO similar tests for set_alarm_hours, get_alarm_hours, get_alarm_weekday_date
-
-  #[test]
-  fn test_set_alarm_weekday_date() {
-    let expectations = [I2cTrans::write(RV3028_ADDRESS, vec![REG_WEEKDAY_DATE_ALARM, RV3028::<I2cMock>::bin_to_bcd(2)])];
-    let mock = I2cMock::new(&expectations);
-    let mut rv3028 = RV3028::new(mock);
-    rv3028.set_alarm_weekday_date(2, true).unwrap();
-  }
-
+  // #[test]
+  // fn test_get_alarm_minutes() {
+  //   let expectations = [
+  //     I2cTrans::write_read(RV3028_ADDRESS, vec![REG_MINUTES_ALARM], vec![RV3028::<I2cMock>::bin_to_bcd(15)]),
+  //   ];
+  //   let mock = I2cMock::new(&expectations);
+  //   let mut rv3028 = RV3028::new(mock);
+  //   assert_eq!(rv3028.get_alarm_minutes().unwrap(), 15);
+  // }
+  //
+  // //TODO similar tests for set_alarm_hours, get_alarm_hours, get_alarm_weekday_date
+  //
+  // #[test]
+  // fn test_set_alarm_weekday_date() {
+  //   let expectations = [I2cTrans::write(RV3028_ADDRESS, vec![REG_WEEKDAY_DATE_ALARM, RV3028::<I2cMock>::bin_to_bcd(2)])];
+  //   let mock = I2cMock::new(&expectations);
+  //   let mut rv3028 = RV3028::new(mock);
+  //   rv3028.set_alarm_weekday_date(2, true).unwrap();
+  // }
+  //
   #[test]
   fn test_set_year_month_day() {
     let expectations = [


### PR DESCRIPTION
Also includes fixes for the fact that the unix timestamp counter registers are completely independent from the other internal BCD registers for eg YMD and HMS